### PR TITLE
Fix spin animation start

### DIFF
--- a/script.js
+++ b/script.js
@@ -85,7 +85,7 @@ function spinWheel() {
     spinStartTimestamp = null;
     if (spinRequest) cancelAnimationFrame(spinRequest);
     document.getElementById('winnerBanner').classList.add('hidden');
-    rotateWheel();
+    spinRequest = requestAnimationFrame(rotateWheel);
 }
 
 function rotateWheel(timestamp) {


### PR DESCRIPTION
## Summary
- ensure `rotateWheel` gets a timestamp by starting spin with `requestAnimationFrame`

## Testing
- `npm test` *(fails: Missing script)*
- `node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68446835f9b4832fa387bf6e2eb6bfbb